### PR TITLE
Allow setting json_encode options when calling getJson()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 vendor
 docs/*
 cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 vendor
 docs/*
 cache

--- a/src/Skyscanner/JsonPath/JsonObject.php
+++ b/src/Skyscanner/JsonPath/JsonObject.php
@@ -242,11 +242,12 @@ class JsonObject
      * Returns the json object encoded as string.
      *
      *
+     * @param int $options [optional]
      * @return string
      */
-    public function getJson()
+    public function getJson($options = 0)
     {
-        return json_encode($this->jsonObject);
+        return json_encode($this->jsonObject, $options);
     }
 
     /**

--- a/src/Skyscanner/JsonPath/JsonObject.php
+++ b/src/Skyscanner/JsonPath/JsonObject.php
@@ -240,12 +240,13 @@ class JsonObject
 
     /**
      * Returns the json object encoded as string.
+     * See http://php.net/manual/en/json.constants.php for more information on the $options bitmask.
      *
+     * @param int $options json_encode options bitmask
      *
-     * @param int $options [optional]
      * @return string
      */
-    public function getJson($options = 0)
+    public function getJson($options=0)
     {
         return json_encode($this->jsonObject, $options);
     }

--- a/tests/Skyscanner/JsonPath/JsonObjectTest.php
+++ b/tests/Skyscanner/JsonPath/JsonObjectTest.php
@@ -842,20 +842,19 @@ class JsonPathTest extends \PHPUnit_Framework_TestCase
             ->add('$', 'À First Timers Only', 'title')
             ->add('$', array(), 'volunteers')
             ->add('$.volunteers[0]', 'Fayçal', 'name');
-
         $expectedJson = '{"author":"\u00d6 Kent C. Dodds","title":"\u00c0 First Timers Only","volunteers":[{"name":"Fay\u00e7al"}]}';
         $this->assertEquals($expectedJson, $jsonObject->getJson());
     }
 
-    public function testGetJsonWithOptionsBitmask()
+    public function testGetJsonWith54OptionsBitmask()
     {
-        $jsonObject = new JsonObject();
-        $jsonObject
-            ->add('$', 'Ö Kent C. Dodds', 'author')
-            ->add('$', 'À First Timers Only', 'title')
-            ->add('$', array(), 'volunteers')
-            ->add('$.volunteers[0]', 'Fayçal', 'name');
-
+        if (version_compare(PHP_VERSION, '5.4', '>=')) {
+            $jsonObject = new JsonObject();
+            $jsonObject
+                ->add('$', 'Ö Kent C. Dodds', 'author')
+                ->add('$', 'À First Timers Only', 'title')
+                ->add('$', array(), 'volunteers')
+                ->add('$.volunteers[0]', 'Fayçal', 'name');
 $expectedJson = <<<EOF
 {
     "author": "Ö Kent C. Dodds",
@@ -867,7 +866,24 @@ $expectedJson = <<<EOF
     ]
 }
 EOF;
-        $this->assertEquals($expectedJson, $jsonObject->getJson(JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+            $this->assertEquals($expectedJson, $jsonObject->getJson(JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+        }
+    }
+
+    public function testGetJsonWith53OptionsBitmask()
+    {
+        if (version_compare(PHP_VERSION, '5.3', '>=')) {
+            $jsonObject = new JsonObject();
+            $jsonObject
+                ->add('$', '<foo>', 'foo')
+                ->add('$', "'bar'", 'bar')
+                ->add('$', '"baz"', 'baz')
+                ->add('$', '&blong&', 'blog')
+                ->add('$', "\xc3\xa9", 'utf');
+            $expectedJson = '{"foo":"\u003Cfoo\u003E","bar":"\u0027bar\u0027","baz":"\u0022baz\u0022","blog":"\u0026blong\u0026","utf":"\u00e9"}';
+            $this->assertEquals($expectedJson, $jsonObject->getJson(JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP));
+        }
+
     }
 
     public function testMagickMethods()

--- a/tests/Skyscanner/JsonPath/JsonObjectTest.php
+++ b/tests/Skyscanner/JsonPath/JsonObjectTest.php
@@ -834,6 +834,42 @@ class JsonPathTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"size":41,"color":"black","meta":{"code":65076}}', $jsonObject->getJson());
     }
 
+    public function testGetJsonWithoutOptionsBitmask()
+    {
+        $jsonObject = new JsonObject();
+        $jsonObject
+            ->add('$', 'Ö Kent C. Dodds', 'author')
+            ->add('$', 'À First Timers Only', 'title')
+            ->add('$', array(), 'volunteers')
+            ->add('$.volunteers[0]', 'Fayçal', 'name');
+
+        $expectedJson = '{"author":"\u00d6 Kent C. Dodds","title":"\u00c0 First Timers Only","volunteers":[{"name":"Fay\u00e7al"}]}';
+        $this->assertEquals($expectedJson, $jsonObject->getJson());
+    }
+
+    public function testGetJsonWithOptionsBitmask()
+    {
+        $jsonObject = new JsonObject();
+        $jsonObject
+            ->add('$', 'Ö Kent C. Dodds', 'author')
+            ->add('$', 'À First Timers Only', 'title')
+            ->add('$', array(), 'volunteers')
+            ->add('$.volunteers[0]', 'Fayçal', 'name');
+
+$expectedJson = <<<EOF
+{
+    "author": "Ö Kent C. Dodds",
+    "title": "À First Timers Only",
+    "volunteers": [
+        {
+            "name": "Fayçal"
+        }
+    ]
+}
+EOF;
+        $this->assertEquals($expectedJson, $jsonObject->getJson(JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+    }
+
     public function testMagickMethods()
     {
         $jsonObject = new JsonObject($this->json);

--- a/tests/Skyscanner/JsonPath/JsonObjectTest.php
+++ b/tests/Skyscanner/JsonPath/JsonObjectTest.php
@@ -848,26 +848,24 @@ class JsonPathTest extends \PHPUnit_Framework_TestCase
 
     public function testGetJsonWithOptionsBitmask()
     {
-        if (version_compare(PHP_VERSION, '5.4', '>=')) {
-            $jsonObject = new JsonObject();
-            $jsonObject
-                ->add('$', 'Ö Kent C. Dodds', 'author')
-                ->add('$', 'À First Timers Only', 'title')
-                ->add('$', array(), 'volunteers')
-                ->add('$.volunteers[0]', 'Fayçal', 'name');
+        $jsonObject = new JsonObject();
+        $jsonObject
+            ->add('$', 'Ö Kent C. Dodds', 'author')
+            ->add('$', 'À First Timers Only', 'title')
+            ->add('$', array(), 'volunteers')
+            ->add('$.volunteers[0]', 'Fayçal', 'name');
 $expectedJson = <<<EOF
 {
-    "author": "Ö Kent C. Dodds",
-    "title": "À First Timers Only",
-    "volunteers": [
-        {
-            "name": "Fayçal"
-        }
-    ]
+"author": "Ö Kent C. Dodds",
+"title": "À First Timers Only",
+"volunteers": [
+    {
+        "name": "Fayçal"
+    }
+]
 }
 EOF;
-            $this->assertEquals($expectedJson, $jsonObject->getJson(JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
-        }
+        $this->assertEquals($expectedJson, $jsonObject->getJson(JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
     }
 
     public function testMagickMethods()

--- a/tests/Skyscanner/JsonPath/JsonObjectTest.php
+++ b/tests/Skyscanner/JsonPath/JsonObjectTest.php
@@ -856,13 +856,13 @@ class JsonPathTest extends \PHPUnit_Framework_TestCase
             ->add('$.volunteers[0]', 'Fayçal', 'name');
 $expectedJson = <<<EOF
 {
-"author": "Ö Kent C. Dodds",
-"title": "À First Timers Only",
-"volunteers": [
-    {
-        "name": "Fayçal"
-    }
-]
+    "author": "Ö Kent C. Dodds",
+    "title": "À First Timers Only",
+    "volunteers": [
+        {
+            "name": "Fayçal"
+        }
+    ]
 }
 EOF;
         $this->assertEquals($expectedJson, $jsonObject->getJson(JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));

--- a/tests/Skyscanner/JsonPath/JsonObjectTest.php
+++ b/tests/Skyscanner/JsonPath/JsonObjectTest.php
@@ -846,7 +846,7 @@ class JsonPathTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedJson, $jsonObject->getJson());
     }
 
-    public function testGetJsonWith54OptionsBitmask()
+    public function testGetJsonWithOptionsBitmask()
     {
         if (version_compare(PHP_VERSION, '5.4', '>=')) {
             $jsonObject = new JsonObject();
@@ -868,22 +868,6 @@ $expectedJson = <<<EOF
 EOF;
             $this->assertEquals($expectedJson, $jsonObject->getJson(JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
         }
-    }
-
-    public function testGetJsonWith53OptionsBitmask()
-    {
-        if (version_compare(PHP_VERSION, '5.3', '>=')) {
-            $jsonObject = new JsonObject();
-            $jsonObject
-                ->add('$', '<foo>', 'foo')
-                ->add('$', "'bar'", 'bar')
-                ->add('$', '"baz"', 'baz')
-                ->add('$', '&blong&', 'blog')
-                ->add('$', "\xc3\xa9", 'utf');
-            $expectedJson = '{"foo":"\u003Cfoo\u003E","bar":"\u0027bar\u0027","baz":"\u0022baz\u0022","blog":"\u0026blong\u0026","utf":"\u00e9"}';
-            $this->assertEquals($expectedJson, $jsonObject->getJson(JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP));
-        }
-
     }
 
     public function testMagickMethods()


### PR DESCRIPTION
So we can customize the returned JSON using the native json_encode options http://php.net/manual/en/function.json-encode.php

Example: 
`$jsonObj->getJson( JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT )`